### PR TITLE
Use direct url to screencast image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick Start
 
 Features
 =========
-![ screencast ](images/authOsio.png)
+![ screencast ](https://raw.githubusercontent.com/fabric8-analytics/vscode-osio-auth/master/images/authOsio.png)
 
 * This extension enables authorization of OSIO services from VSCode.
 


### PR DESCRIPTION
Using direct url fixes the broken image inside vscode